### PR TITLE
Only use liveblocks when logged in

### DIFF
--- a/app/api/liveblocks/route.ts
+++ b/app/api/liveblocks/route.ts
@@ -2,6 +2,7 @@ import { generateName } from "@/app/utils";
 import { getSession } from "@auth0/nextjs-auth0";
 import { Liveblocks } from "@liveblocks/node";
 import { NextResponse } from "next/server";
+import { getRoom } from "../utils/room";
 
 /**
  * Authenticating your Liveblocks application
@@ -16,7 +17,7 @@ export async function POST() {
   const userSession = await getSession();
   const user = userSession?.user;
   const userName = user?.nickname ?? generateName();
-  
+
   const userInfo = {
     name: userName,
     email: user?.email,
@@ -29,9 +30,9 @@ export async function POST() {
   });
 
   // Use a naming pattern to allow access to rooms with a wildcard
-  session.allow(`whos1337`, session.READ_ACCESS);
+  session.allow(getRoom(`whos1337`), session.READ_ACCESS);
 
   const { status, body } = await session.authorize();
-  
+
   return new NextResponse(body, { status });
 }

--- a/app/api/utils/room.ts
+++ b/app/api/utils/room.ts
@@ -1,0 +1,5 @@
+function getRoom(roomName: string) {
+  return `${roomName}-${process.env.NODE_ENV}`;
+}
+
+export { getRoom };

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -21,8 +21,9 @@ export default function Home() {
   const user = useSelf();
   const room = useRoom();
 
-  if (store.user) { room.connect(); }
-
+  useEffect(() => {
+    if (store.user) { room.connect(); }
+  }, [store.user]);
   const fadeStyle: CSSProperties = {
     opacity: isFadingOut ? 0 : 2,
     transition: "opacity 1s ease-in-out",

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,7 +6,7 @@ import { getLocalOffsetTimeZone, getNextTimeZoneFor1337 } from "./utils";
 import { useSharedContext } from "./store";
 import { Flip, ToastContainer, toast } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
-import { useOthersMapped, useSelf } from "@liveblocks/react";
+import { useOthersMapped, useRoom, useSelf } from "@liveblocks/react";
 import { Avatar } from "@nextui-org/avatar";
 
 export default function Home() {
@@ -19,6 +19,9 @@ export default function Home() {
     info: other.info,
   }));
   const user = useSelf();
+  const room = useRoom();
+
+  if (store.user) { room.connect(); }
 
   const fadeStyle: CSSProperties = {
     opacity: isFadingOut ? 0 : 2,
@@ -83,16 +86,27 @@ export default function Home() {
         <br />
         <br />
         <div className="mb-2">
-          <div className="text-lg mb-2">1337ers: </div>
-          <div className="flex items-center justify-center gap-2">
-            <Avatar showFallback name={user?.info.name} src={user?.info.avatar} />
-            {
-            users.map(([connectionId, user]) => {
-              return (
-                <Avatar key={connectionId} showFallback name={user.info?.name} src={user.info?.avatar} />
-              );
-            })}
-          </div>
+          {
+            store.user && (
+              <div>
+                <div className="text-lg mb-2">Online 1337ers: </div>
+                <div className="flex items-center justify-center gap-2">
+                  {
+                    user && (
+                      <Avatar showFallback name={user.info.name} src={user.info.avatar} />
+                    )
+                  }
+                  {
+                    users.map(([connectionId, user]) => {
+                      return (
+                        <Avatar key={connectionId} showFallback name={user.info.name} src={user.info.avatar} />
+                      );
+                    })
+                  }
+                </div>
+              </div>
+            )
+          }
         </div>
         <div className="lg:inline-block lg:text-center lg:justify-center lg:w-[400px]">
           <CreatePost />

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import { ThemeProvider as NextThemesProvider } from "next-themes";
 import { ThemeProviderProps } from "next-themes/dist/types";
 import { LiveblocksProvider, RoomProvider } from "@liveblocks/react";
+import { getRoom } from "./api/utils/room";
 
 export interface ProvidersProps {
   children: React.ReactNode;
@@ -19,7 +20,7 @@ export function Providers({ children, themeProps }: ProvidersProps) {
     <NextUIProvider navigate={router.push}>
       <NextThemesProvider {...themeProps}>
         <LiveblocksProvider authEndpoint={"/api/liveblocks"}>
-          <RoomProvider id={"whos1337"}>
+          <RoomProvider autoConnect={false} id={getRoom("whos1337")}>
             {children}
           </RoomProvider>
         </LiveblocksProvider>

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "@auth0/nextjs-auth0": "^3.5.0",
+    "@auth0/nextjs-auth0": "3.7.0",
     "@liveblocks/client": "^2.20.0",
     "@liveblocks/node": "^2.20.0",
     "@liveblocks/react": "^2.20.0",
@@ -36,7 +36,7 @@
     "framer-motion": "~11.11.7",
     "intl-messageformat": "^10.5.0",
     "luxon": "^3.5.0",
-    "next": "14.2.10",
+    "next": "14.2.25",
     "next-themes": "^0.2.1",
     "pg": "^8.13.0",
     "react": "18.3.1",


### PR DESCRIPTION
This PR ensures we only connect to Liveblocks if we are logged in. This is done to keep those sweet 50 free tier MAU under control. 